### PR TITLE
use graceful-fs to get around possible EMFILE errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var csv = require('csv');
 var path = require('path');
-var fs = require('fs');
+var fs = require('graceful-fs');
 
 var directory = path.join(__dirname, 'osm-landmarks/');
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/osmlab/osm-landmarks",
   "dependencies": {
     "csv": "^1.1.1",
-    "d3-queue": "^3.0.3",
+    "d3-queue": "^3.0.5",
+    "graceful-fs": "^4.1.11",
     "levenshtein": "^1.0.5",
     "minimist": "^1.2.0",
     "query-overpass": "^1.1.3",


### PR DESCRIPTION
If this module is used concurrently on many features, it can fail with an `EMFILE` error in node

see http://stackoverflow.com/questions/8965606/node-and-error-emfile-too-many-open-files#15934766

This adds `graceful-fs` to avoid this problem.

cc @bkowshik @amishas157 @geohacker 